### PR TITLE
Confirmation texts messages

### DIFF
--- a/app/assets/javascripts/status_bar.js
+++ b/app/assets/javascripts/status_bar.js
@@ -17,7 +17,6 @@ function incrementProgressBar(id, data){
   var value = (data.progress_count / data.total_goal_count * 100)
   var bar = $(`div[goal-id="${id}"]`)
   var parent = bar.parent()
-  var fraction = parent.siblings()[1].innerText
   bar.detach()
   bar.css('width', value + '%')
   parent.append(bar)

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -1,10 +1,10 @@
 class Reminder < ApplicationRecord
 
-  def send_confirmation_message(user)
+  def self.send_confirmation_message(user)
     @twilio_number = ENV['TWILIO_NUMBER']
     @client = Twilio::REST::Client.new ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN']
 
-    @client.account.messages.create(
+    @client.messages.create(
       from: @twilio_number,
       to:  user.sanitize_phone_number,
       body: "You've signed up for reminder texts from the Turing Wellness Tracker. You will receive a reminder at the start of the week to set your goals, and a reminder at the end of the week to submit your goals. To opt of texts visit the Wellness Tracker website."
@@ -26,7 +26,7 @@ class Reminder < ApplicationRecord
     # puts message.to
   end
 
-  def send_monday_message
+  def send_sunday_message
     @twilio_number = ENV['TWILIO_NUMBER']
     @client = Twilio::REST::Client.new ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN']
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,13 @@ class User < ApplicationRecord
 
   scope :text_recipients, -> { where(wants_reminder: true) }
 
+  after_update :send_confirmation_message, if: -> { self.wants_reminder? && (wants_reminder_changed? || phone_number_changed?) }
 
+
+  def send_confirmation_message
+    Reminder.send_confirmation_message(self)
+    # Call the method in Reminder class, passing in the user we want notified
+  end
   def sanitize_phone_number
     phone_number.gsub(/-/, '').prepend("+1")
   end


### PR DESCRIPTION
* Update send_confirmation_message methods in reminder and user classes 

* reminder is sent if phone number is changed or if user opts in

@case-eee  another win for today, got the first round of text messages working!  Right now, if a user opts in to receive texts, s/he will receive a confirmation text.  Another (future) task will be implementing delayed_job or heroku scheduler to run weekly reminders. 
